### PR TITLE
2015 refresh

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -7,6 +7,9 @@ chrome.runtime.onInstalled.addListener(function() {
 				// Match on timetable URL
 				new chrome.declarativeContent.PageStateMatcher({
 					pageUrl: {urlContains: "prod.ss.unimelb.edu.au/student/SM/StudentTtable10.aspx"}
+				}),
+				new chrome.declarativeContent.PageStateMatcher({
+					pageUrl: {urlContains: "UoM-Timetable-to-iCal/extension/test/testTimetable1.htm"}
 				})
 			],
 			// Show the page action on this condition

--- a/extension/contentscript.js
+++ b/extension/contentscript.js
@@ -28,12 +28,12 @@ chrome.runtime.sendMessage(message, function(response) {
 	console.log(response.farewell);
 });
 
-var makeIcs = function(weekEvents) {
+var makeIcs = function(startDate, endDate, weekEvents) {
 	if (weekEvents !== true) weekEvents = false;
 	//set up semester boundaries
-	var startingDate = new Date("28 July, 2014");
-	var endingDate = new Date("26 October, 2014");
-	var breakStartDate = new Date("29 September, 2014");
+	var startingDate = new Date(startDate);
+	var endingDate = new Date(endDate);
+	var breakStartDate = new Date("6 April, 2015");
 
 	var dateFormat = function(rawtime, day) {
 		//date fields on page don't match dateSting format for JavaScript
@@ -103,7 +103,11 @@ var makeIcs = function(weekEvents) {
 chrome.runtime.onMessage.addListener(
 	function(request, sender, sendResponse) {
 		if (request.greeting == "makeIcs") {
-			makeIcs(request.weeklyEvents);
+			makeIcs(
+				request.startDate,
+				request.endDate,
+				request.weeklyEvents
+			);
 			sendResponse({farewell: "executed makeIcs()"});
 		}
 	}

--- a/extension/contentscript.js
+++ b/extension/contentscript.js
@@ -5,17 +5,6 @@ var classSelector = ".cssClassContainer";
 var daySelector = ".cssTtbleColDay";
 var subjectSelector = ".cssTtableSspNavContainer"
 
-//find subject and class count
-var message = {
-	greeting: "pageData",
-	classCount: document.querySelectorAll(classSelector).length,
-	subjectCount: document.querySelectorAll(subjectSelector).length
-};
-//send this to the popup
-chrome.runtime.sendMessage(message, function(response) {
-	console.log(response.farewell);
-});
-
 //build subject code -> subject name dictionary
 var subjectMap = {};
 console.log("Building subject code->name map");
@@ -24,7 +13,20 @@ $(".cssTtableSspNavContainer").each(function() {
 	var name =  $(".cssTtableSspNavMasterSpkInfo3 div:first", this).text().trim();
 	console.log(cc+" -> "+name);
 	subjectMap[cc]=name;
-})
+});
+
+//gather page data
+var message = {
+	"greeting": "pageData",
+	"classCount": document.querySelectorAll(classSelector).length,
+	"subjectCount": document.querySelectorAll(subjectSelector).length,
+	"subjectMap": subjectMap
+};
+
+//send this to the popup
+chrome.runtime.sendMessage(message, function(response) {
+	console.log(response.farewell);
+});
 
 var makeIcs = function(weekEvents) {
 	if (weekEvents !== true) weekEvents = false;

--- a/extension/contentscript.js
+++ b/extension/contentscript.js
@@ -1,11 +1,11 @@
 console.log("contentscript.js invoked");
 
-//declare CSS selectors
+// declare CSS selectors
 var classSelector = ".cssClassContainer";
 var daySelector = ".cssTtbleColDay";
 var subjectSelector = ".cssTtableSspNavContainer"
 
-//build subject code -> subject name dictionary
+// build subject code -> subject name dictionary
 var subjectMap = {};
 console.log("Building subject code->name map");
 $(".cssTtableSspNavContainer").each(function() {
@@ -15,7 +15,7 @@ $(".cssTtableSspNavContainer").each(function() {
 	subjectMap[cc]=name;
 });
 
-//gather page data
+// gather page data
 var message = {
 	"greeting": "pageData",
 	"classCount": document.querySelectorAll(classSelector).length,
@@ -23,89 +23,129 @@ var message = {
 	"subjectMap": subjectMap
 };
 
-//send this to the popup
+// send page data to the popup
 chrome.runtime.sendMessage(message, function(response) {
 	console.log(response.farewell);
 });
 
 var makeIcs = function(startDate, endDate, weekEvents) {
+	// parameter defaults
 	if (weekEvents !== true) weekEvents = false;
-	//set up semester boundaries
+	
+	// set up semester boundaries
 	var startingDate = new Date(startDate);
 	var endingDate = new Date(endDate);
 	var breakStartDate = new Date("6 April, 2015");
 
 	var dateFormat = function(rawtime, day) {
-		//date fields on page don't match dateSting format for JavaScript
-		//need to add a space before am/pm and seconds field
-		//rawtime is attached to the given day (date) and returned as a string
+		// date fields on the timetable page don't match dateSting format for JavaScript
+		// need to add a space before am/pm and seconds field
+		// rawtime is attached to the given day (date) and returned as a string
 		var slicePosition = rawtime.length - 2;
 		var newdate = rawtime.slice(0,slicePosition)+':00 '+ rawtime.slice(slicePosition,rawtime.length);
 		return day.toDateString() + " " + newdate;
 	};
 
-	//initialise icalendar library
+	// initialise icalendar library
 	var cal = ics();
 
-	$(daySelector).each(function(dayIndex){
-		//iterating over each weekday
-		//set up variable for the day of the week
+	// If there is a Sunday in the timetable, it appears first.
+	// It's easier to assume Monday is the first day of the week
+	// so this lookup table is used to deal with the day order.
+	
+	var daysIndex = {
+		"Monday": 0,
+		"Tuesday": 1,
+		"Wednesday": 2,
+		"Thursday": 3,
+		"Friday": 4,
+		"Saturday": 5,
+		"Sunday": 6
+	};
+
+	$(daySelector).each(function(index, element){
+		// iterating over each weekday present in the timetable
+
+		// find out what day we're iterating over
+		var day = $(element).find(".cssTtbleColHeaderInner").text().trim();
+		var dayIndex = daysIndex[day];
+
+		if (dayIndex == undefined) {
+			// something went wrong
+			console.log("Error! Invalid day '"+day+"' found in timetable. Skipping");
+			return;
+		}
+
+		console.log("Processing day #"+dayIndex+" ("+day+")");
+
+		// set up variable for the day of the week
 		var weekDay = new Date(startingDate.getTime() + dayIndex*(24 * 60 * 60 * 1000));
-		//set up variable for the mid-semester break offset (used for exlusion)
+
+		// set up variable for the mid-semester break offset (used for exlusion)
 		var exludeDay = new Date(breakStartDate.getTime() + dayIndex*(24 * 60 * 60 * 1000));
-		console.log("DAY #"+dayIndex);
+		
 		$(classSelector, this).each(function(index){
-			//iterating over each subject in a weekday
-			//collect data
+			// iterating over each subject in a weekday
+			// collect data
 			var subjectCode = $(".cssTtableHeaderPanel", this).text().replace(/[\n\t\r]/g,"");
-			//add subject name if found
+			// add subject name if found
 			if (subjectMap[subjectCode]!==undefined) subjectCode += " "+subjectMap[subjectCode];
 			var name = $(".cssTtableClsSlotWhat", this).text().trim();
 			var start = dateFormat($(".cssHiddenStartTm", this).val(),weekDay);
 			var end = dateFormat($(".cssHiddenEndTm", this).val(),weekDay);
 			var location = $(".cssTtableClsSlotWhere", this).text();
-			//determine exlusion date
+			// determine exlusion date
 			var exludeDate = dateFormat($(".cssHiddenStartTm", this).val(),exludeDay);
-			//log and process into event
+			// log and process into event
 			console.log(subjectCode + " " + name + " @ " + location + " \n" + start + " -> " + end + " except "+exludeDate);
 			cal.addEvent(subjectCode+" "+name, name, location, start, end, endingDate, exludeDate);
 		});
 	});
+
 	if (weekEvents) {
-		//create an event for each week #
+		// create an event for each week #
 		var passedBreak = false;
+
 		for(var weeknum=1;weeknum<=13;weeknum++) {
+			// break week doesn't count as a week
+			// need to adjust if we're past it
 			var actualWeekNum = weeknum;
 			if (passedBreak) {
 				actualWeekNum--;
 			}
+
 			var eventName = "Week #"+actualWeekNum.toString();
 			var eventDescription = "University calendar week "+actualWeekNum.toString()
 
 			var weekStartDate = new Date(startingDate.toDateString());
 			weekStartDate.setDate(weekStartDate.getDate()+7*(weeknum-1));
+
 			if (weekStartDate.toDateString() == breakStartDate.toDateString()) {
 				//this week is the break week
 				passedBreak = true;
 				eventName = "Mid-semester break";
 				eventDescription = "University non-teaching period";
 			}
+
 			var weekEndDate = new Date(weekStartDate.toDateString());
 			weekEndDate.setDate(weekStartDate.getDate()+5);
+			
 			cal.addEvent(eventName, eventDescription, "", weekStartDate, weekEndDate);
 		}
 	}
-	//download ics
+	
+	// download ics
 	cal.download("yourCal");
 };
 
-//attach listener from popup
+// attach listener from popup
 chrome.runtime.onMessage.addListener(
 	function(request, sender, sendResponse) {
 		if (request.greeting == "makeIcs") {
 			makeIcs(
 				request.startDate,
 				request.endDate,
+				request.breakStartDate,
 				request.weeklyEvents
 			);
 			sendResponse({farewell: "executed makeIcs()"});

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 2,
 
     "name": "Unimelb Timetable to iCal",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "description": "Converts the Unimelb timetable page into an iCal file",
 
     "icons": {
@@ -23,7 +23,9 @@
     "permissions": [
         "declarativeContent", 
         "tabs", 
-        "https://prod.ss.unimelb.edu.au/*"
+        "https://prod.ss.unimelb.edu.au/*",
+        "http://www.unimelb.edu.au/unisec/PDates/",
+        "file://*/UoM-Timetable-to-iCal/extension/test/*"
     ],
 
     "web_accessible_resources": ["contentscript.js"]

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -24,8 +24,7 @@
         "declarativeContent", 
         "tabs", 
         "https://prod.ss.unimelb.edu.au/*",
-        "http://www.unimelb.edu.au/unisec/PDates/",
-        "file://*/UoM-Timetable-to-iCal/extension/test/*"
+        "http://www.unimelb.edu.au/unisec/PDates/"
     ],
 
     "web_accessible_resources": ["contentscript.js"]

--- a/extension/popup.css
+++ b/extension/popup.css
@@ -101,9 +101,18 @@ fieldset[disabled="disabled"] {
 fieldset[disabled="disabled"] * {
     cursor: not-allowed;
 }
-fieldset .field {
+fieldset > * {
     display: table-row;
 }
-fieldset .field > * {
+fieldset > * > * {
     display: table-cell;
+}
+fieldset > * > *:first-child {
+    text-align: right;
+}
+fieldset .fieldValidation {
+    margin-bottom: 1em;
+}
+fieldset .fieldValidation:last-child {
+    margin-bottom: 0;
 }

--- a/extension/popup.css
+++ b/extension/popup.css
@@ -120,5 +120,9 @@ fieldset .fieldValidation:last-child {
 	margin-bottom: 0;
 }
 fieldset .fieldValidation .validator {
+	display: block;
 	margin-left: 1em;
+	padding: 1px;
+	border: 1px;
+	line-height: 2em;
 }

--- a/extension/popup.css
+++ b/extension/popup.css
@@ -1,0 +1,109 @@
+body {
+    min-width: 357px;
+    overflow-x: hidden;
+    font-family: 'Roboto','Helvetica','Arial', sans-serif;
+    font-weight: 300;
+    color: #111;
+    background-color: #ddd;
+    margin: 0 0 8px 0;
+}
+a {
+    color: #27D;
+}
+h1 {
+    font-size: 1.5em;
+    text-decoration: underline;
+    color: #fff;
+    margin-bottom: 0;
+}
+h2 {
+    font-size: 1.3em;
+    text-decoration: underline;
+}
+h3 {
+    font-size: 1.1em;
+    color:#555;
+}
+ul {
+    padding-left: 2em;
+}
+p, li {
+    font-size: 1em;
+}
+section {
+    margin: 0 2em;
+}
+header {
+    background-color: #036;
+    padding: 3em 0 0.5em 1.5em;
+}
+main {
+    padding: 0 1.5em;
+}
+.radio label {
+    display: block;
+}
+input {
+    margin-left: 1em;
+}
+label#weeklyYN {
+    padding:0 4px;
+}
+#dateSourceFields {
+    margin-bottom: 1em;
+}
+#dateSourceFields select {
+    margin-left: 2em;
+}
+#semesterDatesFetchStatus {
+    margin: 0.5em 0;
+}
+#semesterDatesFetchStatus .success {
+    margin-bottom: 0.5em;
+}
+.fetching {
+    color: #555;
+}
+.success {
+    color: #082;
+}
+.error {
+    color: #C44;
+}
+.notfound {
+    color: #C50;
+}
+input[type="button"] {
+    color: #fff;
+    background-color: #5cb85c;
+    border-color: #4cae4c;
+    border-radius: 4px;
+    padding: 1em;
+    margin: 2em auto;
+    display: block;
+    font-size: 1.2em;
+}
+fieldset {
+    display: table;
+    border: 0;
+    margin: 0;
+    padding: 0.5em 1em;
+    border: 1px solid #555;
+    border-radius: 0.5em;
+    background-color: #ddd;
+}
+fieldset[disabled="disabled"] {
+    cursor: no-drop;
+    border-color: rgb(166, 166, 166);
+    background-color: #eee;
+    color: grey;
+}
+fieldset[disabled="disabled"] * {
+    cursor: not-allowed;
+}
+fieldset .field {
+    display: table-row;
+}
+fieldset .field > * {
+    display: table-cell;
+}

--- a/extension/popup.css
+++ b/extension/popup.css
@@ -1,124 +1,124 @@
 body {
-    min-width: 357px;
-    overflow-x: hidden;
-    font-family: 'Roboto','Helvetica','Arial', sans-serif;
-    font-weight: 300;
-    color: #111;
-    background-color: #ddd;
-    margin: 0 0 8px 0;
+	min-width: 357px;
+	overflow-x: hidden;
+	font-family: 'Roboto','Helvetica','Arial', sans-serif;
+	font-weight: 300;
+	color: #111;
+	background-color: #ddd;
+	margin: 0 0 8px 0;
 }
 a {
-    color: #27D;
+	color: #27D;
 }
 h1 {
-    font-size: 1.5em;
-    text-decoration: underline;
-    color: #fff;
-    margin-bottom: 0;
+	font-size: 1.5em;
+	text-decoration: underline;
+	color: #fff;
+	margin-bottom: 0;
 }
 h2 {
-    font-size: 1.3em;
-    text-decoration: underline;
+	font-size: 1.3em;
+	text-decoration: underline;
 }
 h3 {
-    font-size: 1.1em;
-    color:#555;
+	font-size: 1.1em;
+	color:#555;
 }
 ul {
-    padding-left: 2em;
+	padding-left: 2em;
 }
 p, li {
-    font-size: 1em;
+	font-size: 1em;
 }
 section {
-    margin: 0 2em;
+	margin: 0 2em;
 }
 header {
-    background-color: #036;
-    padding: 3em 0 0.5em 1.5em;
+	background-color: #036;
+	padding: 3em 0 0.5em 1.5em;
 }
 main {
-    padding: 0 1.5em;
+	padding: 0 1.5em;
 }
 .radio label {
-    display: block;
+	display: block;
 }
 input {
-    margin-left: 1em;
+	margin-left: 1em;
 }
 label#weeklyYN {
-    padding:0 4px;
+	padding:0 4px;
 }
 #dateSourceFields {
-    margin-bottom: 1em;
+	margin-bottom: 1em;
 }
 #dateSourceFields select {
-    margin-left: 2em;
+	margin-left: 2em;
 }
 #semesterDatesFetchStatus {
-    margin: 0.5em 0;
+	margin: 0.5em 0;
 }
 #semesterDatesFetchStatus .success {
-    margin-bottom: 0.5em;
+	margin-bottom: 0.5em;
 }
 .fetching {
-    color: #555;
+	color: #555;
 }
 .success {
-    color: #082;
+	color: #082;
 }
 .error {
-    color: #C44;
+	color: #C44;
 }
 .notfound {
-    color: #C50;
+	color: #C50;
 }
 input[type="button"] {
-    color: #fff;
-    background-color: #5cb85c;
-    border-color: #4cae4c;
-    border-radius: 4px;
-    padding: 1em;
-    margin: 2em auto;
-    display: block;
-    font-size: 1.2em;
+	color: #fff;
+	background-color: #5cb85c;
+	border-color: #4cae4c;
+	border-radius: 4px;
+	padding: 1em;
+	margin: 2em auto;
+	display: block;
+	font-size: 1.2em;
 }
 fieldset {
-    display: table;
-    border: 0;
-    margin: 0;
-    padding: 0.5em 1em;
-    border: 1px solid #555;
-    border-radius: 0.5em;
-    background-color: #ddd;
+	display: table;
+	border: 0;
+	margin: 0;
+	padding: 0.5em 1em;
+	border: 1px solid #555;
+	border-radius: 0.5em;
+	background-color: #ddd;
 }
 fieldset[disabled="disabled"] {
-    cursor: no-drop;
-    border-color: rgb(166, 166, 166);
-    background-color: #eee;
-    color: #888;
+	cursor: no-drop;
+	border-color: rgb(166, 166, 166);
+	background-color: #eee;
+	color: #888;
 }
 fieldset[disabled="disabled"] * {
-    cursor: not-allowed;
+	cursor: not-allowed;
 }
 fieldset > * {
-    display: table-row;
+	display: table-row;
 }
 fieldset > * > * {
-    display: table-cell;
+	display: table-cell;
 }
 fieldset > * > *:first-child {
-    text-align: right;
+	text-align: right;
 }
 .fieldset > * > .checkbox {
-    colspan: 2;
+	colspan: 2;
 }
 fieldset .fieldValidation {
-    margin-bottom: 1em;
+	margin-bottom: 1em;
 }
 fieldset .fieldValidation:last-child {
-    margin-bottom: 0;
+	margin-bottom: 0;
 }
 fieldset .fieldValidation .validator {
-    margin-left: 1em;
+	margin-left: 1em;
 }

--- a/extension/popup.css
+++ b/extension/popup.css
@@ -96,7 +96,7 @@ fieldset[disabled="disabled"] {
     cursor: no-drop;
     border-color: rgb(166, 166, 166);
     background-color: #eee;
-    color: grey;
+    color: #888;
 }
 fieldset[disabled="disabled"] * {
     cursor: not-allowed;
@@ -110,9 +110,15 @@ fieldset > * > * {
 fieldset > * > *:first-child {
     text-align: right;
 }
+.fieldset > * > .checkbox {
+    colspan: 2;
+}
 fieldset .fieldValidation {
     margin-bottom: 1em;
 }
 fieldset .fieldValidation:last-child {
     margin-bottom: 0;
+}
+fieldset .fieldValidation .validator {
+    margin-left: 1em;
 }

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -48,6 +48,9 @@
     label#weeklyYN {
         padding:0 4px;
     }
+    #dateSourceFields {
+        margin-bottom: 5px;
+    }
     #dateSourceFields select {
         margin-left: 40px;
     }
@@ -61,8 +64,29 @@
         display: block;
         font-size: 1.2em;
     }
+    fieldset {
+        display: table;
+        border: 0;
+        margin: 0 0 0 10px;
+        padding: 5px 10px;
+        border: 1px solid #555;
+        border-radius: 5px;
+        background-color: #ddd;
+    }
     fieldset[disabled="disabled"] {
-        display: none;
+        cursor: not-allowed;
+        border: 1px solid rgb(166, 166, 166);
+        background-color: #eee;
+        color: grey;
+    }
+    fieldset[disabled="disabled"] * {
+        cursor: not-allowed;
+    }
+    fieldset .field {
+        display: table-row;
+    }
+    fieldset .field > * {
+        display: table-cell;
     }
     </style>
     <!--
@@ -83,8 +107,8 @@
     <div class="main">
         <h2>Detected data</h2>
         <ul>
-            <li><span id="subjectCount">0</span> subjects detected</li>
-            <li><span id="classCount">0</span> classes detected</li>
+            <li id="subjectCount"><span>0</span> subjects detected</li>
+            <li id="classCount"><span>0</span> classes detected</li>
         </ul>
         <h2>Options</h2>
         <form action="">
@@ -101,11 +125,11 @@
                 </label>
             </div>
             <fieldset id="dateFields" disabled="disabled">
-                <div>
+                <div class="field">
                     <label>Starting Date:</label>
                     <input id="startDate" type="text" value="28 July, 2014">
                 </div>
-                <div>
+                <div class="field">
                     <label>Ending Date:</label>
                     <input id="endDate" type="text" value="26 October, 2014">
                 </div>

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -54,7 +54,7 @@
                 </fieldset>
 
                 <p>
-                    <input id ="weeklyYN" type="checkbox" name="weeklyYN" value="">
+                    <input id ="weeklyYN" type="checkbox" name="weeklyYN" value="" checked="checked">
                     <label for="weeklyYN">Add week-long events for each week #</label>
                 </p>
 

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -33,6 +33,7 @@
                         Enter manually
                     </label>
                 </div>
+                
                 <fieldset id="dateFields" disabled="disabled">
                     <div class="field">
                         <label>Starting Date:</label>
@@ -40,7 +41,7 @@
                     </div>
                     <div class="fieldValidation">
                         <span>validated as:</span>
-                        <span id="startDateValidity"></span>
+                        <span id="startDateValidity" class="validator"></span>
                     </div>
                     <div class="field">
                         <label>Ending Date:</label>
@@ -48,13 +49,15 @@
                     </div>
                     <div class="fieldValidation">
                         <span>validated as:</span>
-                        <span id="endDateValidity"></span>
+                        <span id="endDateValidity" class="validator"></span>
                     </div>
                 </fieldset>
+
                 <p>
                     <input id ="weeklyYN" type="checkbox" name="weeklyYN" value="">
                     <label for="weeklyYN">Add week-long events for each week #</label>
                 </p>
+
                 <input type="button" id="scriptStarter" value="Create Timetable"/>
             </form>
         </section>

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -14,15 +14,19 @@
         margin: 0 0 8px 0;
     }
     h1 {
-        font-size: 1.2em;
+        font-size: 1.5em;
         text-decoration: underline;
     }
     h2 {
-        font-size: 1em;
+        font-size: 1.3em;
         text-decoration: underline;
     }
+    h3 {
+        font-size: 1.1em;
+        color:#555;
+    }
     p, li {
-        font-size: 0.8em;
+        font-size: 1em;
     }
     .banner h1 {
         display:inline;
@@ -34,6 +38,9 @@
     }
     .main {
         padding: 0 15px;
+    }
+    .radio label {
+        display: block;
     }
     input[type="checkbox"] {
         margin-left: 20px;
@@ -51,14 +58,18 @@
         display: block;
         font-size: 1.2em;
     }
+    fieldset[disabled="disabled"] {
+        display: none;
+    }
     </style>
     <!--
-		- JavaScript and HTML must be in separate files: see our Content Security
-		- Policy documentation[1] for details and explanation.
-		-
-		- [1]: http://developer.chrome.com/extensions/contentSecurityPolicy.html
-	 -->
-	<link href='http://fonts.googleapis.com/css?family=Roboto:400,300,700' rel='stylesheet' type='text/css'>
+        - JavaScript and HTML must be in separate files: see our Content Security
+        - Policy documentation[1] for details and explanation.
+        -
+        - [1]: http://developer.chrome.com/extensions/contentSecurityPolicy.html
+     -->
+    <link href='http://fonts.googleapis.com/css?family=Roboto:400,300,700' rel='stylesheet' type='text/css'>
+    <script type="text/javascript" src="libs/jquery-2.1.1.min.js"></script>
     <script type="text/javascript" src="popup.js"></script>
 </head>
 
@@ -69,23 +80,35 @@
     <div class="main">
         <h2>Detected data</h2>
         <ul>
-        	<li><span id="subjectCount">0</span> subjects detected</li>
+            <li><span id="subjectCount">0</span> subjects detected</li>
             <li><span id="classCount">0</span> classes detected</li>
         </ul>
         <h2>Options</h2>
         <form action="">
-            <!-- 	<ul>
-    		<li><input type="radio" name="dateSource" value="online">Source from UoM page</li>
-    		<li><input type="radio" name="dateSource" value="custom">Enter manually</li>
-    	</ul> 
-            <p>Starting Date:
-                <input id="startDate" type="text" value="28 July, 2014">
-            </p>
-            <p>Ending Date:
-                <input id="endDate" type="text" value="26 October, 2014">
-            </p>-->
+            <h3>Semester information</h3>
+            <div id="dateSourceFields" class="radio">
+                <label>
+                    <input type="radio" name="dateSource" value="online" checked="checked">
+                    Source from UoM page
+                </label>
+                <label>
+                    <input type="radio" name="dateSource" value="custom">
+                    Enter manually
+                </label>
+            </div>
+            <div id="semesterDatesFetchStatus"></div>
+            <fieldset id="dateFields" disabled="disabled">
+                <div>
+                    <label>Starting Date:</label>
+                    <input id="startDate" type="text" value="28 July, 2014">
+                </div>
+                <div>
+                    <label>Ending Date:</label>
+                    <input id="endDate" type="text" value="26 October, 2014">
+                </div>
+            </fieldset>
             <p>
-            	<input id ="weeklyYN" type="checkbox" name="weeklyYN" value="">
+                <input id ="weeklyYN" type="checkbox" name="weeklyYN" value="">
                 <label for="weeklyYN">Add week-long events for each week #</label>
             </p>
             <input type="button" id="scriptStarter" value="Create Timetable"/>

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -42,11 +42,14 @@
     .radio label {
         display: block;
     }
-    input[type="checkbox"] {
+    input {
         margin-left: 20px;
     }
     label#weeklyYN {
         padding:0 4px;
+    }
+    #dateSourceFields select {
+        margin-left: 40px;
     }
     input[type="button"] {
         color: #fff;
@@ -91,12 +94,12 @@
                     <input type="radio" name="dateSource" value="online" checked="checked">
                     Source from UoM page
                 </label>
+                <div id="semesterDatesFetchStatus"></div>
                 <label>
                     <input type="radio" name="dateSource" value="custom">
                     Enter manually
                 </label>
             </div>
-            <div id="semesterDatesFetchStatus"></div>
             <fieldset id="dateFields" disabled="disabled">
                 <div>
                     <label>Starting Date:</label>

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -3,144 +3,58 @@
 
 <head>
     <title>UoM Timetable to iCal</title>
-    <style type="text/css">
-    body {
-        min-width: 357px;
-        overflow-x: hidden;
-        font-family: 'Roboto','Helvetica','Arial', sans-serif;
-        font-weight: 300;
-        color: #111;
-        background-color: #ddd;
-        margin: 0 0 8px 0;
-    }
-    h1 {
-        font-size: 1.5em;
-        text-decoration: underline;
-    }
-    h2 {
-        font-size: 1.3em;
-        text-decoration: underline;
-    }
-    h3 {
-        font-size: 1.1em;
-        color:#555;
-    }
-    p, li {
-        font-size: 1em;
-    }
-    .banner h1 {
-        display:inline;
-        color:white;
-    }
-    .banner {
-        background-color: #036;
-        padding: 30px 0 5px 15px;
-    }
-    .main {
-        padding: 0 15px;
-    }
-    .radio label {
-        display: block;
-    }
-    input {
-        margin-left: 20px;
-    }
-    label#weeklyYN {
-        padding:0 4px;
-    }
-    #dateSourceFields {
-        margin-bottom: 5px;
-    }
-    #dateSourceFields select {
-        margin-left: 40px;
-    }
-    input[type="button"] {
-        color: #fff;
-        background-color: #5cb85c;
-        border-color: #4cae4c;
-        border-radius: 4px;
-        padding: 10px;
-        margin: 20px auto;
-        display: block;
-        font-size: 1.2em;
-    }
-    fieldset {
-        display: table;
-        border: 0;
-        margin: 0 0 0 10px;
-        padding: 5px 10px;
-        border: 1px solid #555;
-        border-radius: 5px;
-        background-color: #ddd;
-    }
-    fieldset[disabled="disabled"] {
-        cursor: not-allowed;
-        border: 1px solid rgb(166, 166, 166);
-        background-color: #eee;
-        color: grey;
-    }
-    fieldset[disabled="disabled"] * {
-        cursor: not-allowed;
-    }
-    fieldset .field {
-        display: table-row;
-    }
-    fieldset .field > * {
-        display: table-cell;
-    }
-    </style>
-    <!--
-        - JavaScript and HTML must be in separate files: see our Content Security
-        - Policy documentation[1] for details and explanation.
-        -
-        - [1]: http://developer.chrome.com/extensions/contentSecurityPolicy.html
-     -->
+    
     <link href='http://fonts.googleapis.com/css?family=Roboto:400,300,700' rel='stylesheet' type='text/css'>
-    <script type="text/javascript" src="libs/jquery-2.1.1.min.js"></script>
-    <script type="text/javascript" src="popup.js"></script>
+    <link href='popup.css' rel='stylesheet' type='text/css'>
 </head>
 
 <body>
-    <div class="banner">
+    <header>
         <h1>Unimelb Timetable .ics generator</h1>
-    </div>
-    <div class="main">
+    </header>
+    <main>
         <h2>Detected data</h2>
-        <ul>
-            <li id="subjectCount"><span>0</span> subjects detected</li>
-            <li id="classCount"><span>0</span> classes detected</li>
-        </ul>
+        <section>
+            <h3 id="subjectCount"><span>0</span> subjects detected</h3>
+            <h3 id="classCount"><span>0</span> classes detected</h3>
+        </section>
         <h2>Options</h2>
-        <form action="">
-            <h3>Semester information</h3>
-            <div id="dateSourceFields" class="radio">
-                <label>
-                    <input type="radio" name="dateSource" value="online" checked="checked">
-                    Source from UoM page
-                </label>
-                <div id="semesterDatesFetchStatus"></div>
-                <label>
-                    <input type="radio" name="dateSource" value="custom">
-                    Enter manually
-                </label>
-            </div>
-            <fieldset id="dateFields" disabled="disabled">
-                <div class="field">
-                    <label>Starting Date:</label>
-                    <input id="startDate" type="text" value="28 July, 2014">
+        <section>
+            <form action="">
+                <h3>Semester information</h3>
+                <div id="dateSourceFields" class="radio">
+                    <label>
+                        <input type="radio" name="dateSource" value="online" checked="checked">
+                        Source from <a id="principleDatesURL" href="#" target="_blank">UoM principle dates page</a>
+                    </label>
+                    <div id="semesterDatesFetchStatus"></div>
+                    <label>
+                        <input type="radio" name="dateSource" value="custom">
+                        Enter manually
+                    </label>
                 </div>
-                <div class="field">
-                    <label>Ending Date:</label>
-                    <input id="endDate" type="text" value="26 October, 2014">
-                </div>
-            </fieldset>
-            <p>
-                <input id ="weeklyYN" type="checkbox" name="weeklyYN" value="">
-                <label for="weeklyYN">Add week-long events for each week #</label>
-            </p>
-            <input type="button" id="scriptStarter" value="Create Timetable"/>
-        </form>
-    </div>
+                <fieldset id="dateFields" disabled="disabled">
+                    <div class="field">
+                        <label>Starting Date:</label>
+                        <input id="startDate" type="text" value="28 July, 2014">
+                    </div>
+                    <div class="field">
+                        <label>Ending Date:</label>
+                        <input id="endDate" type="text" value="26 October, 2014">
+                    </div>
+                </fieldset>
+                <p>
+                    <input id ="weeklyYN" type="checkbox" name="weeklyYN" value="">
+                    <label for="weeklyYN">Add week-long events for each week #</label>
+                </p>
+                <input type="button" id="scriptStarter" value="Create Timetable"/>
+            </form>
+        </section>
+    </main>
+
+    <script type="text/javascript" src="libs/jquery-2.1.1.min.js"></script>
+    <script type="text/javascript" src="popup.js"></script>
+
 </body>
 
 </html>

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -38,9 +38,17 @@
                         <label>Starting Date:</label>
                         <input id="startDate" type="text" value="28 July, 2014">
                     </div>
+                    <div class="fieldValidation">
+                        <span>validated as:</span>
+                        <span id="startDateValidity"></span>
+                    </div>
                     <div class="field">
                         <label>Ending Date:</label>
                         <input id="endDate" type="text" value="26 October, 2014">
+                    </div>
+                    <div class="fieldValidation">
+                        <span>validated as:</span>
+                        <span id="endDateValidity"></span>
                     </div>
                 </fieldset>
                 <p>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -167,14 +167,15 @@ var sanitizeDateRange = function(dateRange, year) {
 	}
 }
 
-var validateDateField = function(sel) {
+var validateDateField = function(dateSel, validSel) {
 	console.log('validating');
-	console.log(sel);
-	var date = sel.val();
-	if ( isValidDate ( new Date(date) ) ) {
-		sel.removeClass('error').addClass('success');
+	console.log(dateSel);
+	var date = new Date( dateSel.val() );
+	validSel.text(date.toDateString())
+	if ( isValidDate ( date ) ) {
+		dateSel.removeClass('error').addClass('success');
 	} else {
-		sel.removeClass('success').addClass('error');
+		dateSel.removeClass('success').addClass('error');
 	}
 }
 
@@ -187,11 +188,13 @@ var updateFetchedDate = function() {
 	var dates = $('#semesterDates :selected').val().split(',');
 	var startDate = dates[0];
 	var startDateSel = $('#startDate');
+	var startDateValidSel = $('#startDateValidity');
 	var endDate = dates[1];
 	var endDateSel = $('#endDate');
+	var endDateValidSel = $('#endDateValidity');
 
 	startDateSel.val(startDate);
-	validateDateField(startDateSel);
+	validateDateField(startDateSel, startDateValidSel);
 	endDateSel.val(endDate);
-	validateDateField(endDateSel);
+	validateDateField(endDateSel, endDateValidSel);
 }

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -2,9 +2,26 @@
 chrome.runtime.onMessage.addListener(
 	function(request, sender, sendResponse) {
 		if (request.greeting == "pageData") {
-			// content script has sent through class and subject counts
-			document.getElementById("classCount").innerHTML=request.classCount.toString();
-			document.getElementById("subjectCount").innerHTML=request.subjectCount.toString();
+			// content script has sent through class and subject info
+			// process subjects
+			var subjectCountElem = $('#subjectCount');
+			if (request.subjectMap) {
+				var subjectListString = "<ul>";
+				// iterate over subjects
+				for (var subjectCode in request.subjectMap ) {
+					// check to see if we're looking at a Object property or a subjectMap property
+					if (request.subjectMap.hasOwnProperty(subjectCode)) {
+						subjectListString+="<li>"+subjectCode+": "+request.subjectMap[subjectCode]+"</li>";
+					}
+				}
+				subjectListString += "</ul>";
+				subjectCountElem.after(subjectListString);
+			}
+			subjectCountElem.find("span").text(request.subjectCount.toString());
+			
+			// process classes
+			$("#classCount span").text(request.classCount.toString());
+			// done
 			sendResponse({farewell: "goodbye"});
 		}
 	}
@@ -24,7 +41,6 @@ document.addEventListener('DOMContentLoaded', function() {
 			$('#semesterDates').removeAttr("disabled");
 		}
 	});
-	$('.main h2').after('<a href="'+chrome.extension.getURL("test/testTimetable1.htm")+'">Maximise</a>')
 	// run page script
 	chrome.tabs.executeScript(null, {file: "libs/jquery-2.1.1.min.js"});
 	chrome.tabs.executeScript(null, {file: "libs/ics.deps.min.js"});

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -3,195 +3,195 @@ var uniPDatesURL = "http://www.unimelb.edu.au/unisec/PDates/";
 
 // add event listener for incoming messages from the contentscript
 chrome.runtime.onMessage.addListener(
-    function(request, sender, sendResponse) {
-        if (request.greeting == "pageData") {
-            // content script has sent through class and subject info
-            // process subjects
-            var subjectCountElem = $('#subjectCount');
-            if (request.subjectMap) {
-                var subjectListString = "<ul>";
-                // iterate over subjects
-                for (var subjectCode in request.subjectMap ) {
-                    // check to see if we're looking at a Object property or a subjectMap property
-                    if (request.subjectMap.hasOwnProperty(subjectCode)) {
-                        subjectListString+="<li>"+subjectCode+": "+request.subjectMap[subjectCode]+"</li>";
-                    }
-                }
-                subjectListString += "</ul>";
-                subjectCountElem.after(subjectListString);
-            }
-            subjectCountElem.find("span").text(request.subjectCount.toString());
-            
-            // process classes
-            $("#classCount span").text(request.classCount.toString());
-            // done
-            sendResponse({farewell: "Popup successfully retrieved page data"});
-        }
-    }
+	function(request, sender, sendResponse) {
+		if (request.greeting == "pageData") {
+			// content script has sent through class and subject info
+			// process subjects
+			var subjectCountElem = $('#subjectCount');
+			if (request.subjectMap) {
+				var subjectListString = "<ul>";
+				// iterate over subjects
+				for (var subjectCode in request.subjectMap ) {
+					// check to see if we're looking at a Object property or a subjectMap property
+					if (request.subjectMap.hasOwnProperty(subjectCode)) {
+						subjectListString+="<li>"+subjectCode+": "+request.subjectMap[subjectCode]+"</li>";
+					}
+				}
+				subjectListString += "</ul>";
+				subjectCountElem.after(subjectListString);
+			}
+			subjectCountElem.find("span").text(request.subjectCount.toString());
+			
+			// process classes
+			$("#classCount span").text(request.classCount.toString());
+			// done
+			sendResponse({farewell: "Popup successfully retrieved page data"});
+		}
+	}
 );
 
 
 document.addEventListener('DOMContentLoaded', function() {
-    // add script trigger to page button
-    document.getElementById("scriptStarter").addEventListener('click',startScript);
-    
-    // date source options logic
-    $("#dateSourceFields").find('input[name="dateSource"]').on('change', function() {
-        if ($('#dateSourceFields input[name="dateSource"]:checked').val() == "custom") {
-            $('#semesterDates').attr("disabled", "disabled");
-            $('#dateFields').removeAttr("disabled");
-        } else {
-            $('#dateFields').attr("disabled", "disabled");
-            $('#semesterDates').removeAttr("disabled");
-        }
-    });
-    $('#dateFields').find('input').on('change', function() {
-        var sel = $(this);
-        validateDateField(sel);
-    })
-    
-    // attach principle dates URL (keeps URL definition in the one place, here)
-    $('#principleDatesURL').attr('href', uniPDatesURL);
-    
-    // run page script
-    chrome.tabs.executeScript(null, {file: "libs/jquery-2.1.1.min.js"});
-    chrome.tabs.executeScript(null, {file: "libs/ics.deps.min.js"});
-    chrome.tabs.executeScript(null, {file: "libs/ics.js"});
-    chrome.tabs.executeScript(null, {file: "contentscript.js"});
+	// add script trigger to page button
+	document.getElementById("scriptStarter").addEventListener('click',startScript);
+	
+	// date source options logic
+	$("#dateSourceFields").find('input[name="dateSource"]').on('change', function() {
+		if ($('#dateSourceFields input[name="dateSource"]:checked').val() == "custom") {
+			$('#semesterDates').attr("disabled", "disabled");
+			$('#dateFields').removeAttr("disabled");
+		} else {
+			$('#dateFields').attr("disabled", "disabled");
+			$('#semesterDates').removeAttr("disabled");
+		}
+	});
+	$('#dateFields').find('input').on('change', function() {
+		var sel = $(this);
+		validateDateField(sel);
+	})
+	
+	// attach principle dates URL (keeps URL definition in the one place, here)
+	$('#principleDatesURL').attr('href', uniPDatesURL);
+	
+	// run page script
+	chrome.tabs.executeScript(null, {file: "libs/jquery-2.1.1.min.js"});
+	chrome.tabs.executeScript(null, {file: "libs/ics.deps.min.js"});
+	chrome.tabs.executeScript(null, {file: "libs/ics.js"});
+	chrome.tabs.executeScript(null, {file: "contentscript.js"});
 
-    // fetch dates from UoM
-    getSemesterDates();
+	// fetch dates from UoM
+	getSemesterDates();
 });
 
 
 var startScript = function() {
-    console.log("Starting script...");
-    
-    message = {
-        greeting: "makeIcs", 
-        weeklyEvents: document.getElementById("weeklyYN").checked,
-        startDate: document.getElementById("startDate").value,
-        endDate: document.getElementById("endDate").value
+	console.log("Starting script...");
+	
+	message = {
+		greeting: "makeIcs", 
+		weeklyEvents: document.getElementById("weeklyYN").checked,
+		startDate: document.getElementById("startDate").value,
+		endDate: document.getElementById("endDate").value
 
-    }
-    chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
-        chrome.tabs.sendMessage(tabs[0].id, message, function(response) {
-            console.log(response.farewell);
-        });
-    });
+	}
+	chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
+		chrome.tabs.sendMessage(tabs[0].id, message, function(response) {
+			console.log(response.farewell);
+		});
+	});
 };
 
 var getSemesterDates = function() {
-    var pageStatus = document.getElementById("semesterDatesFetchStatus");
-    var results = $('<div id=results></div>');
+	var pageStatus = document.getElementById("semesterDatesFetchStatus");
+	var results = $('<div id=results></div>');
 
-    pageStatus.innerHTML = "<p class=\"fetching\">Attempting to fetch semester dates...</p>";
-    results.load(
-        uniPDatesURL + " #content",
-        "",
-        function(responseText, textStatus, jqXHR) {
-            if ( textStatus == "notmodified" || textStatus == "success") {
-                // whoohoo we got a page
-                // try and find year
-                var year = results.find('h2:contains("Principal Dates")').text().match('[0-9]{4}');
-                if (typeof(year) == "object") {
-                    // assume regex matched
-                    year = year[0];
-                }
-                else {
-                    year = new Date().getFullYear().toString()
-                }
-                // try and find semester dates
-                var dates = [];
-                var datesTable = results.find('table')
+	pageStatus.innerHTML = "<p class=\"fetching\">Attempting to fetch semester dates...</p>";
+	results.load(
+		uniPDatesURL + " #content",
+		"",
+		function(responseText, textStatus, jqXHR) {
+			if ( textStatus == "notmodified" || textStatus == "success") {
+				// whoohoo we got a page
+				// try and find year
+				var year = results.find('h2:contains("Principal Dates")').text().match('[0-9]{4}');
+				if (typeof(year) == "object") {
+					// assume regex matched
+					year = year[0];
+				}
+				else {
+					year = new Date().getFullYear().toString()
+				}
+				// try and find semester dates
+				var dates = [];
+				var datesTable = results.find('table')
 
-                var getData = function(i, e) {
-                    var dateRange = sanitizeDateRange($(e).find('td')[0].innerText, year);
-                    var semester = $(e).find('td')[1].innerText;
-                    dates.push({"semester":semester,"dateRange":dateRange});
-                };
+				var getData = function(i, e) {
+					var dateRange = sanitizeDateRange($(e).find('td')[0].innerText, year);
+					var semester = $(e).find('td')[1].innerText;
+					dates.push({"semester":semester,"dateRange":dateRange});
+				};
 
-                datesTable.find('td:contains("Semester")').parent().each(getData);
-                datesTable.find('td:contains("Term")').parent().each(getData);
-                var resultString = "";
-                if (dates.length > 1) {
-                    resultString = '<p class="success">Successfully retrieved '+dates.length.toString()+' date sets from UoM</p>';
-                    resultString +='<select id="semesterDates">';
-                    for (var i = 0; i < dates.length; i++ ) {
-                        console.log("Found semester: "+JSON.stringify(dates[i]));
-                        resultString += "<option value=\""+dates[i]["dateRange"]+"\" >";
-                        resultString += dates[i]["semester"];
-                        resultString += "</option>";
-                    };
-                    //console.log(dates);
-                    resultString += "</select>";
-                    pageStatus.innerHTML = resultString;
-                    // update date fields
-                    updateFetchedDate();
-                    // set event handler for future updates on selection change
-                    $('#semesterDates').on('change', updateFetchedDate);
+				datesTable.find('td:contains("Semester")').parent().each(getData);
+				datesTable.find('td:contains("Term")').parent().each(getData);
+				var resultString = "";
+				if (dates.length > 1) {
+					resultString = '<p class="success">Successfully retrieved '+dates.length.toString()+' date sets from UoM</p>';
+					resultString +='<select id="semesterDates">';
+					for (var i = 0; i < dates.length; i++ ) {
+						console.log("Found semester: "+JSON.stringify(dates[i]));
+						resultString += "<option value=\""+dates[i]["dateRange"]+"\" >";
+						resultString += dates[i]["semester"];
+						resultString += "</option>";
+					};
+					//console.log(dates);
+					resultString += "</select>";
+					pageStatus.innerHTML = resultString;
+					// update date fields
+					updateFetchedDate();
+					// set event handler for future updates on selection change
+					$('#semesterDates').on('change', updateFetchedDate);
 
-                } else {
-                    // must not have found any dates
-                    pageStatus.innerHTML = '<p class="notfound">Could not find any dates on the UoM principle dates pages. Please enter dates manually below</p>';
-                }
-            } else {
-                console.log("Error fetching dates from "+uniPDatesURL);
-                console.log("Response text: "+responseText);
-                console.log("Response status: "+textStatus);
-                pageStatus.innerHTML = '<p class="error">There was an error retrieving dates from UoM. Please enter dates manually below</p>';
-            }
-    });
+				} else {
+					// must not have found any dates
+					pageStatus.innerHTML = '<p class="notfound">Could not find any dates on the UoM principle dates pages. Please enter dates manually below</p>';
+				}
+			} else {
+				console.log("Error fetching dates from "+uniPDatesURL);
+				console.log("Response text: "+responseText);
+				console.log("Response status: "+textStatus);
+				pageStatus.innerHTML = '<p class="error">There was an error retrieving dates from UoM. Please enter dates manually below</p>';
+			}
+	});
 }
 
 var sanitizeDateRange = function(dateRange, year) {
-    var sanitize = function(string, delimiter) {
-        return string.split(delimiter).map(function(splitStr){return splitStr.trim()+" "+year}).join(',');
-    }
-    if (dateRange.indexOf(' to ') > -1) {
-        // 'to' is the delimiter, swap to comma
-        return sanitize(dateRange,' to ');
-    } else {
-        // something's funky
-        console.log("Can't find a ' to ' divider in date range '"+dateRange+"'... trying to find non-alphanumeric divider character");
-        for (var i=0; i<dateRange.length; i++)
-        {
-            //console.log("char ["+dateRange[i]+"] code #"+dateRange.charCodeAt(i));
-            if (dateRange.charCodeAt(i) > 255) {
-                console.log("Assuming character '"+dateRange[i]+"' at position "+i+" is the divider (character code "+dateRange.charCodeAt(i).toString()+")");
-                return sanitize(dateRange, dateRange[i]);
-            }
-        }
-        console.log("Could not find a divider. ABANDON SHIP (returning unsplit date)");
-        return dateRange;
-    }
+	var sanitize = function(string, delimiter) {
+		return string.split(delimiter).map(function(splitStr){return splitStr.trim()+" "+year}).join(',');
+	}
+	if (dateRange.indexOf(' to ') > -1) {
+		// 'to' is the delimiter, swap to comma
+		return sanitize(dateRange,' to ');
+	} else {
+		// something's funky
+		console.log("Can't find a ' to ' divider in date range '"+dateRange+"'... trying to find non-alphanumeric divider character");
+		for (var i=0; i<dateRange.length; i++)
+		{
+			//console.log("char ["+dateRange[i]+"] code #"+dateRange.charCodeAt(i));
+			if (dateRange.charCodeAt(i) > 255) {
+				console.log("Assuming character '"+dateRange[i]+"' at position "+i+" is the divider (character code "+dateRange.charCodeAt(i).toString()+")");
+				return sanitize(dateRange, dateRange[i]);
+			}
+		}
+		console.log("Could not find a divider. ABANDON SHIP (returning unsplit date)");
+		return dateRange;
+	}
 }
 
 var validateDateField = function(sel) {
-    console.log('validating');
-    console.log(sel);
-    var date = sel.val();
-    if ( isValidDate ( new Date(date) ) ) {
-        sel.removeClass('error').addClass('success');
-    } else {
-        sel.removeClass('success').addClass('error');
-    }
+	console.log('validating');
+	console.log(sel);
+	var date = sel.val();
+	if ( isValidDate ( new Date(date) ) ) {
+		sel.removeClass('error').addClass('success');
+	} else {
+		sel.removeClass('success').addClass('error');
+	}
 }
 
 var isValidDate = function (d) {
-    if ( Object.prototype.toString.call(d) !== "[object Date]" ) return false;
-    return !isNaN(d.getTime());
+	if ( Object.prototype.toString.call(d) !== "[object Date]" ) return false;
+	return !isNaN(d.getTime());
 }
 
 var updateFetchedDate = function() {
-    var dates = $('#semesterDates :selected').val().split(',');
-    var startDate = dates[0];
-    var startDateSel = $('#startDate');
-    var endDate = dates[1];
-    var endDateSel = $('#endDate');
+	var dates = $('#semesterDates :selected').val().split(',');
+	var startDate = dates[0];
+	var startDateSel = $('#startDate');
+	var endDate = dates[1];
+	var endDateSel = $('#endDate');
 
-    startDateSel.val(startDate);
-    validateDateField(startDateSel);
-    endDateSel.val(endDate);
-    validateDateField(endDateSel);
+	startDateSel.val(startDate);
+	validateDateField(startDateSel);
+	endDateSel.val(endDate);
+	validateDateField(endDateSel);
 }

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -25,16 +25,16 @@ chrome.runtime.onMessage.addListener(
             // process classes
             $("#classCount span").text(request.classCount.toString());
             // done
-            sendResponse({farewell: "goodbye"});
+            sendResponse({farewell: "Popup successfully retrieved page data"});
         }
     }
 );
 
-var eventListener;
 
 document.addEventListener('DOMContentLoaded', function() {
     // add script trigger to page button
-    eventListener = document.getElementById("scriptStarter").addEventListener('click',startScript);
+    document.getElementById("scriptStarter").addEventListener('click',startScript);
+    
     // date source options logic
     $("#dateSourceFields").find('input[name="dateSource"]').on('change', function() {
         if ($('#dateSourceFields input[name="dateSource"]:checked').val() == "custom") {
@@ -49,21 +49,24 @@ document.addEventListener('DOMContentLoaded', function() {
         var sel = $(this);
         validateDateField(sel);
     })
+    
     // attach principle dates URL (keeps URL definition in the one place, here)
     $('#principleDatesURL').attr('href', uniPDatesURL);
+    
     // run page script
     chrome.tabs.executeScript(null, {file: "libs/jquery-2.1.1.min.js"});
     chrome.tabs.executeScript(null, {file: "libs/ics.deps.min.js"});
     chrome.tabs.executeScript(null, {file: "libs/ics.js"});
     chrome.tabs.executeScript(null, {file: "contentscript.js"});
 
+    // fetch dates from UoM
     getSemesterDates();
 });
 
 
 var startScript = function() {
     console.log("Starting script...");
-    console.log(eventListener);
+    
     message = {
         greeting: "makeIcs", 
         weeklyEvents: document.getElementById("weeklyYN").checked,

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -45,6 +45,10 @@ document.addEventListener('DOMContentLoaded', function() {
             $('#semesterDates').removeAttr("disabled");
         }
     });
+    $('#dateFields').find('input').on('change', function() {
+        var sel = $(this);
+        validateDateField(sel);
+    })
     // attach principle dates URL (keeps URL definition in the one place, here)
     $('#principleDatesURL').attr('href', uniPDatesURL);
     // run page script
@@ -96,11 +100,16 @@ var getSemesterDates = function() {
                 }
                 // try and find semester dates
                 var dates = [];
-                results.find('table').find('td:contains("Semester"), td:contains("Term")').parent().each(function() {
-                    var dateRange = sanitizeDateRange($(this).find('td')[0].innerText, year);
-                    var semester = $(this).find('td')[1].innerText;
+                var datesTable = results.find('table')
+
+                var getData = function(i, e) {
+                    var dateRange = sanitizeDateRange($(e).find('td')[0].innerText, year);
+                    var semester = $(e).find('td')[1].innerText;
                     dates.push({"semester":semester,"dateRange":dateRange});
-                });
+                };
+
+                datesTable.find('td:contains("Semester")').parent().each(getData);
+                datesTable.find('td:contains("Term")').parent().each(getData);
                 var resultString = "";
                 if (dates.length > 1) {
                     resultString = '<p class="success">Successfully retrieved '+dates.length.toString()+' date sets from UoM</p>';
@@ -155,6 +164,22 @@ var sanitizeDateRange = function(dateRange, year) {
     }
 }
 
+var validateDateField = function(sel) {
+    console.log('validating');
+    console.log(sel);
+    var date = sel.val();
+    if ( isValidDate ( new Date(date) ) ) {
+        sel.removeClass('error').addClass('success');
+    } else {
+        sel.removeClass('success').addClass('error');
+    }
+}
+
+var isValidDate = function (d) {
+    if ( Object.prototype.toString.call(d) !== "[object Date]" ) return false;
+    return !isNaN(d.getTime());
+}
+
 var updateFetchedDate = function() {
     var dates = $('#semesterDates :selected').val().split(',');
     var startDate = dates[0];
@@ -162,19 +187,8 @@ var updateFetchedDate = function() {
     var endDate = dates[1];
     var endDateSel = $('#endDate');
 
-    var isValidDate = function (d) {
-        if ( Object.prototype.toString.call(d) !== "[object Date]" ) return false;
-        return !isNaN(d.getTime());
-    }
-    var setDateField = function(sel, date) {
-        sel.val(date);
-        if ( isValidDate ( new Date(date) ) ) {
-            sel.removeClass('error').addClass('success');
-        } else {
-            sel.removeClass('success').addClass('error');
-        }
-    }
-
-    setDateField(startDateSel, startDate);
-    setDateField(endDateSel, endDate);
+    startDateSel.val(startDate);
+    validateDateField(startDateSel);
+    endDateSel.val(endDate);
+    validateDateField(endDateSel);
 }

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,92 +1,167 @@
+// declare variables
+var uniPDatesURL = "http://www.unimelb.edu.au/unisec/PDates/";
+
 // add event listener for incoming messages from the contentscript
 chrome.runtime.onMessage.addListener(
-	function(request, sender, sendResponse) {
-		if (request.greeting == "pageData") {
-			// content script has sent through class and subject info
-			// process subjects
-			var subjectCountElem = $('#subjectCount');
-			if (request.subjectMap) {
-				var subjectListString = "<ul>";
-				// iterate over subjects
-				for (var subjectCode in request.subjectMap ) {
-					// check to see if we're looking at a Object property or a subjectMap property
-					if (request.subjectMap.hasOwnProperty(subjectCode)) {
-						subjectListString+="<li>"+subjectCode+": "+request.subjectMap[subjectCode]+"</li>";
-					}
-				}
-				subjectListString += "</ul>";
-				subjectCountElem.after(subjectListString);
-			}
-			subjectCountElem.find("span").text(request.subjectCount.toString());
-			
-			// process classes
-			$("#classCount span").text(request.classCount.toString());
-			// done
-			sendResponse({farewell: "goodbye"});
-		}
-	}
+    function(request, sender, sendResponse) {
+        if (request.greeting == "pageData") {
+            // content script has sent through class and subject info
+            // process subjects
+            var subjectCountElem = $('#subjectCount');
+            if (request.subjectMap) {
+                var subjectListString = "<ul>";
+                // iterate over subjects
+                for (var subjectCode in request.subjectMap ) {
+                    // check to see if we're looking at a Object property or a subjectMap property
+                    if (request.subjectMap.hasOwnProperty(subjectCode)) {
+                        subjectListString+="<li>"+subjectCode+": "+request.subjectMap[subjectCode]+"</li>";
+                    }
+                }
+                subjectListString += "</ul>";
+                subjectCountElem.after(subjectListString);
+            }
+            subjectCountElem.find("span").text(request.subjectCount.toString());
+            
+            // process classes
+            $("#classCount span").text(request.classCount.toString());
+            // done
+            sendResponse({farewell: "goodbye"});
+        }
+    }
 );
 
 var eventListener;
 
 document.addEventListener('DOMContentLoaded', function() {
-	// add script trigger to page button
-	eventListener = document.getElementById("scriptStarter").addEventListener('click',startScript);
-	$("#dateSourceFields").find('input[name="dateSource"]').on('change', function() {
-		if ($('#dateSourceFields input[name="dateSource"]:checked').val() == "custom") {
-			$('#semesterDates').attr("disabled", "disabled");
-			$('#dateFields').removeAttr("disabled");
-		} else {
-			$('#dateFields').attr("disabled", "disabled");
-			$('#semesterDates').removeAttr("disabled");
-		}
-	});
-	// run page script
-	chrome.tabs.executeScript(null, {file: "libs/jquery-2.1.1.min.js"});
-	chrome.tabs.executeScript(null, {file: "libs/ics.deps.min.js"});
-	chrome.tabs.executeScript(null, {file: "libs/ics.js"});
-	chrome.tabs.executeScript(null, {file: "contentscript.js"});
+    // add script trigger to page button
+    eventListener = document.getElementById("scriptStarter").addEventListener('click',startScript);
+    // date source options logic
+    $("#dateSourceFields").find('input[name="dateSource"]').on('change', function() {
+        if ($('#dateSourceFields input[name="dateSource"]:checked').val() == "custom") {
+            $('#semesterDates').attr("disabled", "disabled");
+            $('#dateFields').removeAttr("disabled");
+        } else {
+            $('#dateFields').attr("disabled", "disabled");
+            $('#semesterDates').removeAttr("disabled");
+        }
+    });
+    // attach principle dates URL (keeps URL definition in the one place, here)
+    $('#principleDatesURL').attr('href', uniPDatesURL);
+    // run page script
+    chrome.tabs.executeScript(null, {file: "libs/jquery-2.1.1.min.js"});
+    chrome.tabs.executeScript(null, {file: "libs/ics.deps.min.js"});
+    chrome.tabs.executeScript(null, {file: "libs/ics.js"});
+    chrome.tabs.executeScript(null, {file: "contentscript.js"});
 
-	getSemesterDates();
+    getSemesterDates();
 });
 
 
 var startScript = function() {
-	console.log("Starting script...");
-	console.log(eventListener);
-	message = {
-		greeting: "makeIcs", 
-		weeklyEvents: document.getElementById("weeklyYN").checked
-	}
-	chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
-		chrome.tabs.sendMessage(tabs[0].id, message, function(response) {
-			console.log(response.farewell);
-		});
-	});
+    console.log("Starting script...");
+    console.log(eventListener);
+    message = {
+        greeting: "makeIcs", 
+        weeklyEvents: document.getElementById("weeklyYN").checked
+    }
+    chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
+        chrome.tabs.sendMessage(tabs[0].id, message, function(response) {
+            console.log(response.farewell);
+        });
+    });
 };
 
 var getSemesterDates = function() {
-	var pageStatus = document.getElementById("semesterDatesFetchStatus");
-	pageStatus.innerHTML = "<p>Attempting to fetch semester dates...</p>";
-	var results = $('<div id=results></div>');
-	results.load("http://www.unimelb.edu.au/unisec/PDates/ #content", "", function() {
-		//pageStatus.innerHTML = results.html();
-		var dates = [];
-		results.find('table td:contains("Semester")').parent().each(function() {
-			var daterange = $(this).find('td')[0].innerText;
-			var semester = $(this).find('td')[1].innerText;
-			dates.push({"semester":semester,"daterange":daterange});
-		});
-		console.log(dates);
-		var resultString='<select id="semesterDates">';
-		for (var i = 0; i < dates.length; i++ ) {
-			console.log("Found semester: "+JSON.stringify(dates[i]));
-			resultString += "<option value=\""+dates[i]["daterange"]+"\" >";
-			resultString += dates[i]["semester"];
-			resultString += "</option>";
-		};
-		resultString += "</select>";
-		pageStatus.innerHTML = resultString;
-	});
+    var pageStatus = document.getElementById("semesterDatesFetchStatus");
+    var results = $('<div id=results></div>');
 
+    pageStatus.innerHTML = "<p class=\"fetching\">Attempting to fetch semester dates...</p>";
+    results.load(
+        uniPDatesURL + " #content",
+        "",
+        function(responseText, textStatus, jqXHR) {
+            if ( textStatus == "notmodified" || textStatus == "success") {
+                // whoohoo we got a page
+                var dates = [];
+                results.find('table').find('td:contains("Semester"), td:contains("Term")').parent().each(function() {
+                    var dateRange = sanitizeDateRange($(this).find('td')[0].innerText);
+                    var semester = $(this).find('td')[1].innerText;
+                    dates.push({"semester":semester,"dateRange":dateRange});
+                });
+                var resultString = "";
+                if (dates.length > 1) {
+                    resultString = '<p class="success">Successfully retrieved '+dates.length.toString()+' date sets from UoM</p>';
+                    resultString +='<select id="semesterDates">';
+                    for (var i = 0; i < dates.length; i++ ) {
+                        console.log("Found semester: "+JSON.stringify(dates[i]));
+                        resultString += "<option value=\""+dates[i]["dateRange"]+"\" >";
+                        resultString += dates[i]["semester"];
+                        resultString += "</option>";
+                    };
+                    //console.log(dates);
+                    resultString += "</select>";
+                    pageStatus.innerHTML = resultString;
+                    // update date fields
+                    updateFetchedDate();
+                    // set event handler for future updates on selection change
+                    $('#semesterDates').on('change', updateFetchedDate);
+
+                } else {
+                    // must not have found any dates
+                    pageStatus.innerHTML = '<p class="notfound">Could not find any dates on the UoM principle dates pages. Please enter dates manually below</p>';
+                }
+            } else {
+                console.log("Error fetching dates from "+uniPDatesURL);
+                console.log("Response text: "+responseText);
+                console.log("Response status: "+textStatus);
+                pageStatus.innerHTML = '<p class="error">There was an error retrieving dates from UoM. Please enter dates manually below</p>';
+            }
+    });
+}
+
+var sanitizeDateRange = function(dateRange) {
+    var sanitize = function(string, delimiter) {
+        return string.split(delimiter).map(function(splitStr){return splitStr.trim()}).join(',');
+    }
+    if (dateRange.indexOf(' to ') > -1) {
+        // 'to' is the delimiter, swap to comma
+        return sanitize(dateRange,' to ');
+    } else {
+        // something's funky
+        console.log("Can't find a ' to ' divider in date range '"+dateRange+"'... trying to find non-alphanumeric divider character");
+        for (var i=0; i<dateRange.length; i++)
+        {
+            //console.log("char ["+dateRange[i]+"] code #"+dateRange.charCodeAt(i));
+            if (dateRange.charCodeAt(i) > 255) {
+                console.log("Assuming character '"+dateRange[i]+"' at position "+i+" is the divider (character code "+dateRange.charCodeAt(i).toString()+")");
+                return sanitize(dateRange, dateRange[i]);
+            }
+        }
+        console.log("Could not find a divider. ABANDON SHIP (returning unsplit date)");
+        return dateRange;
+    }
+}
+
+var updateFetchedDate = function() {
+    var dates = $('#semesterDates :selected').val().split(',');
+    var startDate = dates[0];
+    var startDateSel = $('#startDate');
+    var endDate = dates[1];
+    var endDateSel = $('#endDate');
+
+    var isValidDate = function (d) {
+        if ( Object.prototype.toString.call(d) !== "[object Date]" ) return false;
+        return !isNaN(d.getTime());
+    }
+    var setDateField = function(sel, date) {
+        sel.val(date);
+        if ( isValidDate ( new Date(date) ) ) {
+            sel.removeClass('error').addClass('success');
+        } else {
+            sel.removeClass('success').addClass('error');
+        }
+    }
+
+    setDateField(startDateSel, startDate);
+    setDateField(endDateSel, endDate);
 }

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -17,11 +17,14 @@ document.addEventListener('DOMContentLoaded', function() {
 	eventListener = document.getElementById("scriptStarter").addEventListener('click',startScript);
 	$("#dateSourceFields").find('input[name="dateSource"]').on('change', function() {
 		if ($('#dateSourceFields input[name="dateSource"]:checked').val() == "custom") {
+			$('#semesterDates').attr("disabled", "disabled");
 			$('#dateFields').removeAttr("disabled");
 		} else {
 			$('#dateFields').attr("disabled", "disabled");
+			$('#semesterDates').removeAttr("disabled");
 		}
 	});
+	$('.main h2').after('<a href="'+chrome.extension.getURL("test/testTimetable1.htm")+'">Maximise</a>')
 	// run page script
 	chrome.tabs.executeScript(null, {file: "libs/jquery-2.1.1.min.js"});
 	chrome.tabs.executeScript(null, {file: "libs/ics.deps.min.js"});
@@ -48,7 +51,26 @@ var startScript = function() {
 
 var getSemesterDates = function() {
 	var pageStatus = document.getElementById("semesterDatesFetchStatus");
-	pageStatus.innerText = "Attempting to fetch semester dates...";
-	var xhr = new XMLHttpRequest();
-	xhr.open("GET", "http://www.unimelb.edu.au/unisec/PDates/");
+	pageStatus.innerHTML = "<p>Attempting to fetch semester dates...</p>";
+	var results = $('<div id=results></div>');
+	results.load("http://www.unimelb.edu.au/unisec/PDates/ #content", "", function() {
+		//pageStatus.innerHTML = results.html();
+		var dates = [];
+		results.find('table td:contains("Semester")').parent().each(function() {
+			var daterange = $(this).find('td')[0].innerText;
+			var semester = $(this).find('td')[1].innerText;
+			dates.push({"semester":semester,"daterange":daterange});
+		});
+		console.log(dates);
+		var resultString='<select id="semesterDates">';
+		for (var i = 0; i < dates.length; i++ ) {
+			console.log("Found semester: "+JSON.stringify(dates[i]));
+			resultString += "<option value=\""+dates[i]["daterange"]+"\" >";
+			resultString += dates[i]["semester"];
+			resultString += "</option>";
+		};
+		resultString += "</select>";
+		pageStatus.innerHTML = resultString;
+	});
+
 }

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,7 +1,8 @@
+// add event listener for incoming messages from the contentscript
 chrome.runtime.onMessage.addListener(
 	function(request, sender, sendResponse) {
 		if (request.greeting == "pageData") {
-			var datesURL = "http://www.unimelb.edu.au/unisec/PDates/";
+			// content script has sent through class and subject counts
 			document.getElementById("classCount").innerHTML=request.classCount.toString();
 			document.getElementById("subjectCount").innerHTML=request.subjectCount.toString();
 			sendResponse({farewell: "goodbye"});
@@ -12,11 +13,22 @@ chrome.runtime.onMessage.addListener(
 var eventListener;
 
 document.addEventListener('DOMContentLoaded', function() {
+	// add script trigger to page button
 	eventListener = document.getElementById("scriptStarter").addEventListener('click',startScript);
+	$("#dateSourceFields").find('input[name="dateSource"]').on('change', function() {
+		if ($('#dateSourceFields input[name="dateSource"]:checked').val() == "custom") {
+			$('#dateFields').removeAttr("disabled");
+		} else {
+			$('#dateFields').attr("disabled", "disabled");
+		}
+	});
+	// run page script
 	chrome.tabs.executeScript(null, {file: "libs/jquery-2.1.1.min.js"});
 	chrome.tabs.executeScript(null, {file: "libs/ics.deps.min.js"});
 	chrome.tabs.executeScript(null, {file: "libs/ics.js"});
 	chrome.tabs.executeScript(null, {file: "contentscript.js"});
+
+	getSemesterDates();
 });
 
 
@@ -33,3 +45,10 @@ var startScript = function() {
 		});
 	});
 };
+
+var getSemesterDates = function() {
+	var pageStatus = document.getElementById("semesterDatesFetchStatus");
+	pageStatus.innerText = "Attempting to fetch semester dates...";
+	var xhr = new XMLHttpRequest();
+	xhr.open("GET", "http://www.unimelb.edu.au/unisec/PDates/");
+}


### PR DESCRIPTION
## Features added so far:

* Dates now bubble through to the content script so they're no longer hard coded
* Dynamic scraping of semester dates from UoM academic calendar
* Fallback fields for manually entering the dates in case they're wrong

## Bugs/caveats

* Mid-semester break is still hard-coded. The code for this will need to be re-written for dynamic scraping as the MSB dates on the academic calendar for semester 1 this year are non-standard (starts on a Friday rather than a Monday because of easter)

## Features to add

* Clearer date validation - at the moment any string that successfully turns into a date will 'validate', which can lead to misleading results. Solution: output the validated Date objects back onto the page in seperate read-only fields. This provides additional confirmation of how the script will behave as well
* Some more metrics on the data being produced would be neat (number of weeks)
* Dynamic scraping of date ranges for semester breaks?