### PR TITLE
2016 update - Support for new Principal Dates page

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Chrome Extension that converts the University of Melbourne timetable page into a
 
 Whenever you reach the UoM timetable page, an icon will appear in the address bar. Click on it to bring up the settings popup, then click the 'Create Timetable' button to trigger the script and generate your iCal file.
 
+## Development notes
+
+It can be useful to test the plugin on a saved local copy of a timetable - to do this, edit the manifest.json file to require permissions for file:// URLs that will cover the location of the saved copy (e.g. "file://*/UoM-Timetable-to-iCal/extension/test/*") and then reload the plugin in development mode.
+
 # Credits
 
 * **ncwell** on GitHub for making the [ics.js](https://github.com/nwcell/ics.js/) library. Apologies for making an absolute mess of it adding in the ability to do repeats and exclusions - I promise I'll tidy it up and send a pull request soon.

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 2,
 
     "name": "Unimelb Timetable to iCal",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "description": "Converts the Unimelb timetable page into an iCal file",
 
     "icons": {
@@ -27,7 +27,8 @@
         "declarativeContent", 
         "tabs", 
         "https://prod.ss.unimelb.edu.au/*",
-        "http://www.unimelb.edu.au/unisec/PDates/"
+        "http://www.unimelb.edu.au/unisec/PDates/",
+        "file://*/UoM-Timetable-to-iCal/extension/test/*"
     ],
 
     "web_accessible_resources": ["contentscript.js"]

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -58,7 +58,7 @@
                     <label for="weeklyYN">Add week-long events for each week #</label>
                 </p>
 
-                <input type="button" id="scriptStarter" value="Create Timetable"/>
+                <input type="button" id="timetableScriptTrigger" value="Create Timetable"/>
             </form>
         </section>
     </main>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -107,6 +107,7 @@ var getSemesterDates = function() {
 
 				// try and find semester dates for each year
 				var dates = [];
+				var matchedSearchNodes = [];
 				
 				years.each(function(index, element) {
 					// iterating over each potential calendar year
@@ -144,6 +145,22 @@ var getSemesterDates = function() {
 					}
 					if (foundContentNode == false) {
 						console.log("Error trying to find table of dates for year " + year + " - could not find #content node");
+						return;
+					}
+
+					// test to see if this node has already been matched to avoid duplicates.
+					//
+					// this is necessary as the :contains selector used to search for years
+					// will match nested elements - e.g.
+					//     $(':contains("sometext")')
+					// called on
+					//     <p><span>sometext</span></p>
+					// will match both <p> and <span>
+					//
+					if (matchedSearchNodes.indexOf(current) === -1) {
+						matchedSearchNodes.push(current);
+					} else {
+						// already searched this node!
 						return;
 					}
 

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -54,10 +54,14 @@ document.addEventListener('DOMContentLoaded', function() {
 			$('#semesterDates').removeAttr("disabled");
 		}
 	});
-	$('#dateFields').find('input').on('change', function() {
+	$('#startDate').on('change', function() {
 		var sel = $(this);
-		validateDateField(sel);
-	})
+		validateDateField(sel, $('#startDateValidity'));
+	});
+	$('#endDate').on('change', function() {
+		var sel = $(this);
+		validateDateField(sel, $('#endDateValidity'));
+	});
 	
 	// attach principle dates URL (keeps URL definition in the one place, here)
 	$('#principleDatesURL').attr('href', uniPDatesURL);

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,13 +1,19 @@
-// declare variables
+// constants
+//==========
+
+// URL to fetch Semester dates from
 var uniPDatesURL = "http://www.unimelb.edu.au/unisec/PDates/";
+
+// plugin setup
+//=============
 
 // add event listener for incoming messages from the contentscript
 chrome.runtime.onMessage.addListener(
 	function(request, sender, sendResponse) {
 		if (request.greeting == "pageData") {
-			// content script has sent through class and subject info
-			// process subjects
+			// content script has sent through class and subject info.
 			var subjectCountElem = $('#subjectCount');
+			// process subjects
 			if (request.subjectMap) {
 				var subjectListString = "<ul>";
 				// iterate over subjects
@@ -30,14 +36,17 @@ chrome.runtime.onMessage.addListener(
 	}
 );
 
+// page setup
+//===========
 
 document.addEventListener('DOMContentLoaded', function() {
 	// add script trigger to page button
-	$("#scriptStarter").off().on('click',startScript);
+	$("#timetableScriptTrigger").off().on('click',startScript);
 	
 	// date source options logic
 	$("#dateSourceFields").find('input[name="dateSource"]').on('change', function() {
-		if ($('#dateSourceFields input[name="dateSource"]:checked').val() == "custom") {
+		var dateSource = $('#dateSourceFields input[name="dateSource"]:checked').val();
+		if (dateSource == "custom") {
 			$('#semesterDates').attr("disabled", "disabled");
 			$('#dateFields').removeAttr("disabled");
 		} else {
@@ -63,7 +72,7 @@ document.addEventListener('DOMContentLoaded', function() {
 	getSemesterDates();
 });
 
-
+// function for communicating with contentscript.js and triggering calendar file creation
 var startScript = function() {
 	console.log("Starting script...");
 	
@@ -72,8 +81,8 @@ var startScript = function() {
 		weeklyEvents: document.getElementById("weeklyYN").checked,
 		startDate: document.getElementById("startDate").value,
 		endDate: document.getElementById("endDate").value
+	};
 
-	}
 	chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
 		chrome.tabs.sendMessage(tabs[0].id, message, function(response) {
 			console.log(response.farewell);
@@ -81,6 +90,7 @@ var startScript = function() {
 	});
 };
 
+// function for fetching dates from the UoM principle dates calendar
 var getSemesterDates = function() {
 	var pageStatus = document.getElementById("semesterDatesFetchStatus");
 	var results = $('<div id=results></div>');
@@ -113,6 +123,7 @@ var getSemesterDates = function() {
 
 				datesTable.find('td:contains("Semester")').parent().each(getData);
 				datesTable.find('td:contains("Term")').parent().each(getData);
+
 				var resultString = "";
 				if (dates.length > 1) {
 					resultString = '<p class="success">Successfully retrieved '+dates.length.toString()+' date sets from UoM</p>';
@@ -144,6 +155,7 @@ var getSemesterDates = function() {
 	});
 }
 
+// function for splitting fuzzy date ranges from the UoM page into seperate, distinct dates
 var sanitizeDateRange = function(dateRange, year) {
 	var sanitize = function(string, delimiter) {
 		return string.split(delimiter).map(function(splitStr){return splitStr.trim()+" "+year}).join(',');
@@ -167,6 +179,7 @@ var sanitizeDateRange = function(dateRange, year) {
 	}
 }
 
+// event handler for validating manually entered dates
 var validateDateField = function(dateSel, validSel) {
 	console.log('validating');
 	console.log(dateSel);

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -254,10 +254,12 @@ var sanitizeDateRange = function(dateRange, year) {
 	}
 }
 
-// event handler for validating manually entered dates
+// event handler for validating date strings by parsing them with Date
+//
+// dateSel: jQuery selector of field to get date string from
+// validSel: jQuery selector of field to write validated date to
+//
 var validateDateField = function(dateSel, validSel) {
-	console.log('validating');
-	console.log(dateSel);
 	var date = new Date( dateSel.val() );
 	validSel.text(date.toDateString())
 	if ( isValidDate ( date ) ) {


### PR DESCRIPTION
Thanks to a report from @lberezy in issue #3, it has been revealed that the great institution that is the University of Melbourne has changed both the layout, and the URL, of the page that they present their Principal Dates from - a move that has no doubt broken both the dodgy jQuery content scrapers of unofficial UoM plugins everywhere, and the hearts of their authors.

This PR is for an update to the plugin to cope with these monstrous bureaucratic changes, and also hopefully to provide some comforting descriptive comments to any future developer (myself included) who edits this code in the future.