### PR TITLE
Fix for semester 2 2019 break + auto semester selection

### DIFF
--- a/extension/contentscript.js
+++ b/extension/contentscript.js
@@ -47,7 +47,9 @@ var makeIcs = function(startDate, endDate, weekEvents) {
 	//
 	// 2018 sem1 notes: the break is actually Friday 30 March to Sunday 8 April,
 	// but 2 April is used for reasons listed above.
-	var breakStartDate = new Date("24 September, 2018");
+	// var breakStartDate = new Date("2 April, 2018");
+	// var breakStartDate = new Date("24 September, 2018");
+	var breakStartDate = new Date("30 September, 2019");
 
 	var dateFormat = function(rawtime, day) {
 		// date fields on the timetable page don't match dateSting format for JavaScript

--- a/extension/contentscript.js
+++ b/extension/contentscript.js
@@ -47,7 +47,7 @@ var makeIcs = function(startDate, endDate, weekEvents) {
 	//
 	// 2018 sem1 notes: the break is actually Friday 30 March to Sunday 8 April,
 	// but 2 April is used for reasons listed above.
-	var breakStartDate = new Date("2 April, 2018");
+	var breakStartDate = new Date("24 September, 2018");
 
 	var dateFormat = function(rawtime, day) {
 		// date fields on the timetable page don't match dateSting format for JavaScript

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -148,7 +148,7 @@ var getSemesterDates = function() {
 				}
 
 				// Setup array for holding any found dates
-				var dates = [];
+				var foundSemesters = [];
 
 				// Grab the table of dates for the current year
 				var datesTable = results.find('table');
@@ -161,7 +161,7 @@ var getSemesterDates = function() {
 					var sanitizedDateRange = sanitizeDateRangeText(dateRangeText, year);
 					var semesterDescription = $rowElem.find('td')[1].innerText.trim();
 
-					dates.push({
+					foundSemesters.push({
 						"year": year,
 						"semester": semesterDescription,
 						"dateRange": sanitizedDateRange
@@ -177,11 +177,11 @@ var getSemesterDates = function() {
 				// Report information about fetched data to the user
 
 				var resultString = "";
-				if (dates.length > 1) {
-					resultString = '<p class="success">Successfully retrieved '+dates.length.toString()+' date sets from UoM</p>';
+				if (foundSemesters.length > 1) {
+					resultString = '<p class="success">Successfully retrieved '+foundSemesters.length.toString()+' date sets from UoM</p>';
 					resultString +='<select id="semesterDates">';
-					for (var i = 0; i < dates.length; i++ ) {
-						var date = dates[i];
+					for (var i = 0; i < foundSemesters.length; i++ ) {
+						var date = foundSemesters[i];
 						console.log("Found semester: "+JSON.stringify(date));
 						resultString += "<option value=\""+date["dateRange"]+"\" >";
 						resultString += date["year"] + ": " + date["semester"];

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -176,14 +176,51 @@ var getSemesterDates = function() {
 
 				// Report information about fetched data to the user
 
-				var resultString = "";
 				if (foundSemesters.length > 1) {
-					resultString = '<p class="success">Successfully retrieved '+foundSemesters.length.toString()+' date sets from UoM</p>';
+					// bazinga, we got some dates
+
+					// First, pre-process the dates to try and find the most
+					// useful semester to set as selected by default
+					//
+					// the 'most useful' semester is simply defined as
+					// the one with the start date closest to right now
+					var bestDefaultSemesterIndex = undefined;
+					var lowestSemesterStartDistance = undefined;
+					for (var i = 0; i < foundSemesters.length; i++ ) {
+						var date = foundSemesters[i];
+
+						// do a bit of a safety check first, to avoid any errors
+						// caused here by weird data - want to make sure even
+						// in this case that at least something gets put into
+						// the checkbox afterwards
+						if (date["dateRange"] && $.type(date["dateRange"] === "string")) {
+							var splitDates = date["dateRange"].split(',');
+							if (splitDates.length < 2) {
+								console.log("default semester detection - could not find two dates in date range string '" + date["dateRange"] + "' (foundSemesters index " + i.toString() + " of " + foundSemesters.length.toString() + ")");
+								continue;
+							}
+							var parsedStartDate = new Date(splitDates[0]);
+							var parsedEndDate = new Date(splitDates[1]);
+							var rightNow = new Date();
+
+
+							var semesterStartDistance = Math.abs(rightNow.getTime() - parsedStartDate.getTime());
+
+							if ((lowestSemesterStartDistance == undefined) || (semesterStartDistance < lowestSemesterStartDistance)) {
+								lowestSemesterStartDistance = semesterStartDistance;
+								bestDefaultSemesterIndex = i;
+							}
+						}
+					};
+
+					var resultString = '<p class="success">Successfully retrieved '+foundSemesters.length.toString()+' date sets from UoM</p>';
 					resultString +='<select id="semesterDates">';
 					for (var i = 0; i < foundSemesters.length; i++ ) {
 						var date = foundSemesters[i];
 						console.log("Found semester: "+JSON.stringify(date));
-						resultString += "<option value=\""+date["dateRange"]+"\" >";
+
+						var isSemesterSelected = (bestDefaultSemesterIndex !== undefined && i == bestDefaultSemesterIndex) ? true : false;
+						resultString += "<option value=\""+date["dateRange"]+"\" " + (isSemesterSelected ? "selected" : "") + ">";
 						resultString += date["year"] + ": " + date["semester"];
 						resultString += "</option>";
 					};

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -100,6 +100,9 @@ var getSemesterDates = function() {
 	var results = $('<div id=results></div>');
 
 	pageStatus.innerHTML = '<p class="fetching">Attempting to fetch semester dates...</p>';
+	// use jquery's .load() to get the HTML from the unimelb principal dates
+	// page parsed and inserted into results element, so that it can be locally
+	// searched with jQuery
 	results.load(
 		uniPDatesURL + " #main-content",
 		"",

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -183,7 +183,10 @@ var getSemesterDates = function() {
 					// useful semester to set as selected by default
 					//
 					// the 'most useful' semester is simply defined as
-					// the one with the start date closest to right now
+					// the one with the start date closest to right now.
+					// a slightly more useful way to calculate this might
+					// be to also check if the current date is within one
+					// of the semester date ranges.
 					var bestDefaultSemesterIndex = undefined;
 					var lowestSemesterStartDistance = undefined;
 					for (var i = 0; i < foundSemesters.length; i++ ) {


### PR DESCRIPTION
* Update the hard-coded break date for 2019 semester 2
* Add code that will try and select the most relevant semester as a default for the semester choice dropdown box
* Misc code cleanup and commenting